### PR TITLE
fix: enable color modal and multi-track playback

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -39,7 +39,6 @@
   </div>
 
   <audio id="audio" crossorigin="anonymous" preload="none"></audio>
-  <script src="./app.js"></script>
 
   <div id="modal" class="modal">
     <div class="panel">
@@ -53,7 +52,7 @@
       </div>
     </div>
   </div>
-</body>
-</html>
 
+  <script src="./app.js"></script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- ensure color picker modal loads correctly by moving script and adding null checks
- fix playlist queue and URL handling so multiple tracks play reliably
- skip unsupported FLAC sources and advance on audio errors

## Testing
- `python3 scripts/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0a866f2348333afe98ea6d1ee4e8f