### PR TITLE
fix: handle base path and copy config

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -8,11 +8,19 @@ const cAccent = document.getElementById('c-accent');
 const cStop1 = document.getElementById('c-stop1');
 const cStop2 = document.getElementById('c-stop2');
 const cRing = document.getElementById('c-ring');
+const ASSET_BASE = new URL('.', document.currentScript?.src || location.href);
 
 async function applyConfig(){
   try{
-    const res = await fetch('./config.json?ts='+Date.now());
-    const cfg = await res.json();
+    let cfg = {};
+    try {
+      const url = new URL('config.json', ASSET_BASE);
+      url.searchParams.set('ts', Date.now());
+      const res = await fetch(url.toString(), { cache: 'no-store' });
+      if (res.ok) cfg = await res.json();
+    } catch (e) {
+      // ignore missing config
+    }
     const themePref = localStorage.getItem('player.theme') || cfg.defaultTheme || 'auto';
     setTheme(themePref);
     const saved = JSON.parse(localStorage.getItem('player.colors')||'null');
@@ -264,7 +272,9 @@ function filterTracks(){
 
 async function load(){
   await applyConfig();
-  const res = await fetch('./index.json?ts=' + Date.now());
+  const idxUrl = new URL('index.json', ASSET_BASE);
+  idxUrl.searchParams.set('ts', Date.now());
+  const res = await fetch(idxUrl.toString());
   const data = await res.json();
   allTracks = data.tracks || [];
   filteredTracks = allTracks.slice();
@@ -289,7 +299,7 @@ function playIndex(idx, autoplay=true){
   currentIndex = idx;
   const tr = queue[idx];
   const url = pickBestSource(tr.sources);
-  audio.src = url;
+  audio.src = new URL(url, ASSET_BASE).toString();
   npTitle.textContent = tr.title || '—';
   npArtist.textContent = tr.artist || tr.album || tr.groupPath || '—';
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -115,6 +115,8 @@ def main():
     shutil.copy2(SITE_DIR / "index.html", DIST_DIR / "index.html")
     shutil.copy2(SITE_DIR / "style.css", DIST_DIR / "style.css")
     shutil.copy2(SITE_DIR / "app.js", DIST_DIR / "app.js")
+    if (SITE_DIR / "config.json").exists():
+        shutil.copy2(SITE_DIR / "config.json", DIST_DIR / "config.json")
 
     tracks = []
     for p in MUSIC_DIR.rglob("*"):

--- a/site/app.js
+++ b/site/app.js
@@ -8,18 +8,19 @@ const cAccent = document.getElementById('c-accent');
 const cStop1 = document.getElementById('c-stop1');
 const cStop2 = document.getElementById('c-stop2');
 const cRing = document.getElementById('c-ring');
+const ASSET_BASE = new URL('.', document.currentScript?.src || location.href);
 
 async function applyConfig(){
   try{
     let cfg = {};
-try {
-  const base = new URL('.', document.currentScript.src);      
-  const url  = new URL('config.json', base);
-  const res  = await fetch(url.toString() + '?ts=' + Date.now(), { cache: 'no-store' });
-  if (res.ok) cfg = await res.json();
-} catch (e) {
-
-}
+    try {
+      const url = new URL('config.json', ASSET_BASE);
+      url.searchParams.set('ts', Date.now());
+      const res = await fetch(url.toString(), { cache: 'no-store' });
+      if (res.ok) cfg = await res.json();
+    } catch (e) {
+      // ignore missing config
+    }
     const themePref = localStorage.getItem('player.theme') || cfg.defaultTheme || 'auto';
     setTheme(themePref);
     const saved = JSON.parse(localStorage.getItem('player.colors')||'null');
@@ -271,7 +272,9 @@ function filterTracks(){
 
 async function load(){
   await applyConfig();
-  const res = await fetch('./index.json?ts=' + Date.now());
+  const idxUrl = new URL('index.json', ASSET_BASE);
+  idxUrl.searchParams.set('ts', Date.now());
+  const res = await fetch(idxUrl.toString());
   const data = await res.json();
   allTracks = data.tracks || [];
   filteredTracks = allTracks.slice();
@@ -296,7 +299,7 @@ function playIndex(idx, autoplay=true){
   currentIndex = idx;
   const tr = queue[idx];
   const url = pickBestSource(tr.sources);
-  audio.src = url;
+  audio.src = new URL(url, ASSET_BASE).toString();
   npTitle.textContent = tr.title || '—';
   npArtist.textContent = tr.artist || tr.album || tr.groupPath || '—';
 


### PR DESCRIPTION
## Summary
- resolve config and index paths relative to script to avoid 404s and playback failures
- copy site/config.json into build output

## Testing
- `node --check site/app.js`
- `node --check dist/app.js`
- `python -m py_compile scripts/build.py`
- `python scripts/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1c7dede08833382d945c05625dcee